### PR TITLE
Fix proxy target name

### DIFF
--- a/proxy/prod.conf
+++ b/proxy/prod.conf
@@ -1,4 +1,4 @@
-upstream api {
+upstream app {
     server localhost:8000;
 }
 


### PR DESCRIPTION
The NGINX proxy is failing in prod because it can't resolve the `app` hostname:

```
2024/06/18 18:08:32 [emerg] 1#1: host not found in upstream "app" in /etc/nginx/includes/proxy.conf:20
nginx: [emerg] host not found in upstream "app" in /etc/nginx/includes/proxy.conf:20
```

It's only trying to resolve it because it's not configured as an upstream. This should fix that.

@stupendousC and I suspect this will fix things. @soldni please TAL and merge as you see fit!